### PR TITLE
Add filters to the logback-save.xml

### DIFF
--- a/src/main/resources/logback-save.xml
+++ b/src/main/resources/logback-save.xml
@@ -3,26 +3,26 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender" debug="true">
         <target>System.out</target>
-        <filter class="ch.qos.logback.classic.filter.LevelFilter">
-            <level>TRACE</level>
-            <onMatch>ACCEPT</onMatch>
-            <onMismatch>NEUTRAL</onMismatch>
-        </filter>
-        <filter class="ch.qos.logback.classic.filter.LevelFilter">
-            <level>DEBUG</level>
-            <onMatch>ACCEPT</onMatch>
-            <onMismatch>NEUTRAL</onMismatch>
-        </filter>
-        <filter class="ch.qos.logback.classic.filter.LevelFilter">
-            <level>INFO</level>
-            <onMatch>ACCEPT</onMatch>
-            <onMismatch>NEUTRAL</onMismatch>
-        </filter>
-        <filter class="ch.qos.logback.classic.filter.LevelFilter">
-            <level>WARN</level>
-            <onMatch>ACCEPT</onMatch>
-            <onMismatch>DENY</onMismatch>
-        </filter>
+            <filter class="ch.qos.logback.classic.filter.LevelFilter">
+                <level>TRACE</level>
+                <onMatch>ACCEPT</onMatch>
+                <onMismatch>NEUTRAL</onMismatch>
+            </filter>
+            <filter class="ch.qos.logback.classic.filter.LevelFilter">
+                <level>DEBUG</level>
+                <onMatch>ACCEPT</onMatch>
+                <onMismatch>NEUTRAL</onMismatch>
+            </filter>
+            <filter class="ch.qos.logback.classic.filter.LevelFilter">
+                <level>INFO</level>
+                <onMatch>ACCEPT</onMatch>
+                <onMismatch>NEUTRAL</onMismatch>
+            </filter>
+            <filter class="ch.qos.logback.classic.filter.LevelFilter">
+                <level>WARN</level>
+                <onMatch>ACCEPT</onMatch>
+                <onMismatch>DENY</onMismatch>
+            </filter>
         <encoder>
             <pattern>%d{MM/dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n
             </pattern>
@@ -31,6 +31,26 @@
        <appender name="FILE" class="ch.qos.logback.core.FileAppender">
         <file>${log.name}</file>
         <target>System.out</target>
+           <filter class="ch.qos.logback.classic.filter.LevelFilter">
+               <level>TRACE</level>
+               <onMatch>ACCEPT</onMatch>
+               <onMismatch>NEUTRAL</onMismatch>
+           </filter>
+           <filter class="ch.qos.logback.classic.filter.LevelFilter">
+               <level>DEBUG</level>
+               <onMatch>ACCEPT</onMatch>
+               <onMismatch>NEUTRAL</onMismatch>
+           </filter>
+           <filter class="ch.qos.logback.classic.filter.LevelFilter">
+               <level>INFO</level>
+               <onMatch>ACCEPT</onMatch>
+               <onMismatch>NEUTRAL</onMismatch>
+           </filter>
+           <filter class="ch.qos.logback.classic.filter.LevelFilter">
+               <level>WARN</level>
+               <onMatch>ACCEPT</onMatch>
+               <onMismatch>DENY</onMismatch>
+           </filter>
         <encoder>
           <pattern>%d{MM/dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n
           </pattern>
@@ -39,11 +59,11 @@
 
     <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
         <target>System.err</target>
-        <filter class="ch.qos.logback.classic.filter.LevelFilter">
-            <level>ERROR</level>
-            <onMatch>ACCEPT</onMatch>
-            <onMismatch>DENY</onMismatch>
-        </filter>
+            <filter class="ch.qos.logback.classic.filter.LevelFilter">
+                <level>ERROR</level>
+                <onMatch>ACCEPT</onMatch>
+                <onMismatch>DENY</onMismatch>
+            </filter>
         <encoder>
             <pattern>%d{MM/dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n
             </pattern>


### PR DESCRIPTION
Currently, the logback-save.xml file does not respect the user specified log level. This pull request adds the appropriate filters to the logback-save.xml file so that the filter level is respected in the saved log file.