### PR TITLE
Fix isCandidateBundleStructureValid

### DIFF
--- a/src/main/java/net/helix/hlx/utils/bundle/BundleUtils.java
+++ b/src/main/java/net/helix/hlx/utils/bundle/BundleUtils.java
@@ -64,7 +64,9 @@ public class BundleUtils {
     public void create(byte[] data, long tag, Boolean sign, int keyIndex, int maxKeyIndex, String keyfile, int security) {
 
         // get number of transactions needed for tips
-        int n = (data.length/TransactionViewModel.SIGNATURE_MESSAGE_FRAGMENT_SIZE) + 1;
+        int n = data.length % TransactionViewModel.SIGNATURE_MESSAGE_FRAGMENT_SIZE == 0 ?
+                data.length/TransactionViewModel.SIGNATURE_MESSAGE_FRAGMENT_SIZE :
+                (data.length/TransactionViewModel.SIGNATURE_MESSAGE_FRAGMENT_SIZE) + 1;
         // pad data to mutiple of smf
         byte[] paddedData = new byte[n * TransactionViewModel.SIGNATURE_MESSAGE_FRAGMENT_SIZE];
         System.arraycopy(data, 0, paddedData, 0, data.length);


### PR DESCRIPTION
Problem was at bundle creation, the number of sender transaction was not computed correctly if the data was multiple of 512 bytes, because of this, for registration_bundle (with security level 1) bundle has 4 transaction instead of 3.