### PR TITLE
fix forking by maven-surefy-plugin causing Docker build errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -313,8 +313,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.21.0</version>
-                <configuration>
+                <version>3.0.0-M3</version>
+		<configuration>
+	            <forkCount>0</forkCount>
                     <excludes>
                         <exclude>integration/*.java</exclude>
                     </excludes>


### PR DESCRIPTION
```
docker build . 
```
was causing errors. Fix based on: https://stackoverflow.com/questions/49578847/maven-error-occurred-in-starting-fork-check-output-in-log