### PR TITLE
Fix MilestoneCandidate processing

### DIFF
--- a/src/main/java/net/helix/pendulum/conf/BasePendulumConfig.java
+++ b/src/main/java/net/helix/pendulum/conf/BasePendulumConfig.java
@@ -1062,7 +1062,7 @@ public abstract class BasePendulumConfig implements PendulumConfig {
         String PREVIOUS_EPOCHS_SPENT_ADDRESSES_TXT = "/previousEpochsSpentAddresses.txt";
         String PREVIOUS_EPOCHS_SPENT_ADDRESSES_SIG = "/previousEpochsSpentAddresses.sig";
         long GLOBAL_SNAPSHOT_TIME = 1522235533L;
-        int MILESTONE_START_INDEX = 1808542;
+        int MILESTONE_START_INDEX = 0;
         int NUM_KEYS_IN_MILESTONE = 10;
         int MAX_ANALYZED_TXS = 20_000;
 


### PR DESCRIPTION
this fixes the issue that milestoneCandidates were skipped for validation, as falsely declared as too old.

```
// if the milestone is older than our ledger start point: we already processed it in the past
if (roundIndex <= snapshotProvider.getInitialSnapshot().getIndex()) {
    return true;
}
```
`MILESTONE_START_INDEX` is the initial snap index (`snapshotProvider.getInitialSnapshot().getIndex()`).