### PR TITLE
Fix issues in confirmation 

### DIFF
--- a/src/main/java/net/helix/pendulum/conf/BasePendulumConfig.java
+++ b/src/main/java/net/helix/pendulum/conf/BasePendulumConfig.java
@@ -890,11 +890,8 @@ public abstract class BasePendulumConfig implements PendulumConfig {
 
     @Override
     public boolean isValidatorEnabled() {
-        if (isValidator() &&
-                (new File(getValidatorKeyfile()).isFile() || new File(getValidatorSeedfile()).isFile())) {
-            return true;
-        }
-        return false;
+        return (isValidator() &&
+                (new File(getValidatorKeyfile()).isFile() || new File(getValidatorSeedfile()).isFile()));
     }
 
     @Override

--- a/src/main/java/net/helix/pendulum/controllers/RoundViewModel.java
+++ b/src/main/java/net/helix/pendulum/controllers/RoundViewModel.java
@@ -382,6 +382,7 @@ public class RoundViewModel {
      */
     public Set<Hash> getReferencedTransactions(Tangle tangle, Set<Hash> tips) throws Exception {
 
+        Set<Hash> seenTransactions = new HashSet<Hash>();
         Set<Hash> transactions = new HashSet<>();
         final Queue<Hash> nonAnalyzedTransactions = new LinkedList<>(tips);
         Hash hashPointer;
@@ -392,8 +393,16 @@ public class RoundViewModel {
                 // we can add the tx to confirmed transactions, because it is a parent of confirmedTips
                 transactions.add(hashPointer);
                 // traverse parents and add new candidates to queue
-                nonAnalyzedTransactions.offer(transaction.getTrunkTransactionHash());
-                nonAnalyzedTransactions.offer(transaction.getBranchTransactionHash());
+                if(!seenTransactions.contains(transaction.getTrunkTransactionHash())){
+                    seenTransactions.add(transaction.getTrunkTransactionHash());
+                    nonAnalyzedTransactions.offer(transaction.getTrunkTransactionHash());
+                }
+
+                if(!seenTransactions.contains(transaction.getBranchTransactionHash())){
+                    seenTransactions.add(transaction.getBranchTransactionHash());
+                    nonAnalyzedTransactions.offer(transaction.getBranchTransactionHash());
+                }
+
             // roundIndex already set, i.e. tx is already confirmed.
             } else {
                 break;

--- a/src/main/java/net/helix/pendulum/controllers/RoundViewModel.java
+++ b/src/main/java/net/helix/pendulum/controllers/RoundViewModel.java
@@ -334,6 +334,7 @@ public class RoundViewModel {
         Map<Hash, Integer> occurrences = new HashMap<>();
         int quorum = 2 *  BasePendulumConfig.Defaults.NUMBER_OF_ACTIVE_VALIDATORS / 3;
 
+
         for (Hash milestoneHash : getHashes()) {
             Set<Hash> tips = getTipSet(tangle, milestoneHash, security);
 
@@ -364,7 +365,7 @@ public class RoundViewModel {
      * @throws Exception Exception
      */
     public boolean isTransactionConfirmed(Tangle tangle, int security, Hash transaction) throws Exception {
-        Set<Hash> confirmedTransactions = getReferencedTransactions(tangle, getConfirmedTips(tangle, security));
+        Set<Hash> confirmedTransactions = getReferencedTransactions(tangle, getConfirmedTips(tangle, security), true);
         return confirmedTransactions.contains(transaction);
     }
 
@@ -374,22 +375,32 @@ public class RoundViewModel {
      * We mainly use it to count transaction.confirmations in MilestoneTracker.
      * In the future we could use DAGHelper to traverse tangle,
      * but as this method currently does not work with the finality update, we use this as a helper to count confirmations.
+     * If allTransactions is true than all transaction referenced by milestone are processes until a round index != is found,
+     * otherwise only tips and transactions that belongs in their bundles are processed.
      *
      * @param tangle tangle
      * @param tips tips
+     * @param allTransactions allTransactions
      * @return Set of traversed transaction hashes that are parents of the provided tip set
      * @throws Exception Exception
      */
-    public Set<Hash> getReferencedTransactions(Tangle tangle, Set<Hash> tips) throws Exception {
+    public Set<Hash> getReferencedTransactions(Tangle tangle, Set<Hash> tips, boolean allTransactions) throws Exception {
 
         Set<Hash> seenTransactions = new HashSet<Hash>();
+        Set<Hash> tipsBundleHashes = new HashSet<Hash>();
         Set<Hash> transactions = new HashSet<>();
+
         final Queue<Hash> nonAnalyzedTransactions = new LinkedList<>(tips);
         Hash hashPointer;
         while ((hashPointer = nonAnalyzedTransactions.poll()) != null) {
             final TransactionViewModel transaction = fromHash(tangle, hashPointer);
+
+            if(!allTransactions && tips.contains(hashPointer) && !tipsBundleHashes.contains(transaction.getBundleHash())){
+                tipsBundleHashes.add(transaction.getBundleHash());
+            }
             // take only transactions into account that aren't confirmed yet or that belong to the round
-            if (transaction.getRoundIndex() == 0 || transaction.getRoundIndex() == index()) {
+            if ( (allTransactions || tipsBundleHashes.contains(transaction.getBundleHash()))
+                    && (transaction.getRoundIndex() == 0 || transaction.getRoundIndex() == index())) {
                 // we can add the tx to confirmed transactions, because it is a parent of confirmedTips
                 transactions.add(hashPointer);
                 // traverse parents and add new candidates to queue
@@ -402,10 +413,9 @@ public class RoundViewModel {
                     seenTransactions.add(transaction.getBranchTransactionHash());
                     nonAnalyzedTransactions.offer(transaction.getBranchTransactionHash());
                 }
-
-            // roundIndex already set, i.e. tx is already confirmed.
+                // roundIndex already set, i.e. tx is already confirmed.
             } else {
-                break;
+                continue;
             }
         }
         return transactions;

--- a/src/main/java/net/helix/pendulum/model/persistables/Hashes.java
+++ b/src/main/java/net/helix/pendulum/model/persistables/Hashes.java
@@ -4,7 +4,6 @@ import net.helix.pendulum.model.Hash;
 import net.helix.pendulum.model.HashFactory;
 import net.helix.pendulum.storage.Persistable;
 import org.apache.commons.lang3.ArrayUtils;
-import org.junit.internal.Classes;
 
 import java.util.LinkedHashSet;
 import java.util.Set;

--- a/src/main/java/net/helix/pendulum/model/persistables/Hashes.java
+++ b/src/main/java/net/helix/pendulum/model/persistables/Hashes.java
@@ -4,6 +4,7 @@ import net.helix.pendulum.model.Hash;
 import net.helix.pendulum.model.HashFactory;
 import net.helix.pendulum.storage.Persistable;
 import org.apache.commons.lang3.ArrayUtils;
+import org.junit.internal.Classes;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -39,7 +40,7 @@ public class Hashes implements Persistable {
     */
     @Override
     public void read(byte[] bytes) {
-        read(bytes, 0);
+        read(bytes, 0, Transaction.class);
     }
 
     /**
@@ -47,11 +48,11 @@ public class Hashes implements Persistable {
     * @param bytes is a <code> byte[] </code>
     * @param offset the offset defining the start point for hash objects in the array
     */
-    protected void read(byte[] bytes, int offset) {
+    protected void read(byte[] bytes, int offset, Class<?> c) {
         if (bytes != null) {
             set = new LinkedHashSet<>((bytes.length - offset) / (1 + Hash.SIZE_IN_BYTES) + 1);
             for (int i = offset; i < bytes.length; i += 1 + Hash.SIZE_IN_BYTES) {
-                set.add(HashFactory.TRANSACTION.create(bytes, i, Hash.SIZE_IN_BYTES));
+                set.add(HashFactory.GENERIC.create(c, bytes, i, Hash.SIZE_IN_BYTES));
             }
         }
     }

--- a/src/main/java/net/helix/pendulum/model/persistables/Round.java
+++ b/src/main/java/net/helix/pendulum/model/persistables/Round.java
@@ -19,7 +19,7 @@ public class Round extends Hashes {
     public void read(byte[] bytes) {
         if (bytes != null) {
             index = new IntegerIndex(Serializer.getInteger(bytes));
-            read(bytes, Integer.BYTES);
+            read(bytes, Integer.BYTES, Transaction.class);
         }
     }
 }

--- a/src/main/java/net/helix/pendulum/model/persistables/Validator.java
+++ b/src/main/java/net/helix/pendulum/model/persistables/Validator.java
@@ -16,7 +16,7 @@ public class Validator extends Hashes {
     public void read(byte[] bytes) {
         if (bytes != null) {
             index = new IntegerIndex(Serializer.getInteger(bytes));
-            read(bytes, Integer.BYTES);
+            read(bytes, Integer.BYTES, Address.class);
         }
     }
 }

--- a/src/main/java/net/helix/pendulum/service/API.java
+++ b/src/main/java/net/helix/pendulum/service/API.java
@@ -1775,8 +1775,7 @@ public class API {
             final List<String> tips = getParameterAsList(request, "tips", HASH_SIZE);
 
             try {
-                //return getConfirmationStatesStatement(transactions); //todo: when working as expected
-                return getInclusionStatesStatement(transactions, tips);
+                return getConfirmationStatesStatement(transactions);
             } catch (Exception e) {
                 throw new IllegalStateException(e);
             }

--- a/src/main/java/net/helix/pendulum/service/milestone/impl/MilestoneServiceImpl.java
+++ b/src/main/java/net/helix/pendulum/service/milestone/impl/MilestoneServiceImpl.java
@@ -363,9 +363,11 @@ public class MilestoneServiceImpl implements MilestoneService {
         try {
             // update milestones
             RoundViewModel round = RoundViewModel.get(tangle, newIndex);
-            for (Hash milestoneHash : round.getHashes()){
-                TransactionViewModel milestoneTx = TransactionViewModel.fromHash(tangle, milestoneHash);
-                updateRoundIndexOfSingleTransaction(milestoneTx, newIndex);
+            if(round != null) {
+                for (Hash milestoneHash : round.getHashes()) {
+                    TransactionViewModel milestoneTx = TransactionViewModel.fromHash(tangle, milestoneHash);
+                    updateRoundIndexOfSingleTransaction(milestoneTx, newIndex);
+                }
             }
             // update confirmed transactions
             final Queue<Hash> transactionsToUpdate = new LinkedList<>(getConfirmedTips(newIndex));

--- a/src/main/java/net/helix/pendulum/service/milestone/impl/MilestoneTrackerImpl.java
+++ b/src/main/java/net/helix/pendulum/service/milestone/impl/MilestoneTrackerImpl.java
@@ -186,7 +186,7 @@ public class MilestoneTrackerImpl implements MilestoneTracker {
     public void setRoundIndexAndConfirmations(RoundViewModel currentRVM, TransactionViewModel transaction,  int roundIndex) throws Exception {
         //TODO: Fix this for confirmationStates
          // milestone referenced tip set
-         Set<Hash> referencedTipSet = currentRVM.getReferencedTransactions(tangle, RoundViewModel.getTipSet(tangle, transaction.getHash(), config.getValidatorSecurity()), false);
+         Set<Hash> referencedTipSet = currentRVM.getReferencedTransactions(tangle, RoundViewModel.getTipSet(tangle, transaction.getHash(), config.getValidatorSecurity()));
          // Milestone that first references a transaction determines the roundIndex - it should not change after that.
          // The confirmation counter should be incremented with each milestone reference
          for (Hash tx : referencedTipSet) {

--- a/src/main/java/net/helix/pendulum/service/milestone/impl/MilestoneTrackerImpl.java
+++ b/src/main/java/net/helix/pendulum/service/milestone/impl/MilestoneTrackerImpl.java
@@ -192,7 +192,9 @@ public class MilestoneTrackerImpl implements MilestoneTracker {
          for (Hash tx : referencedTipSet) {
              TransactionViewModel txvm = TransactionViewModel.fromHash(tangle, tx);
              txvm.setRoundIndex(txvm.getRoundIndex() == 0 ? roundIndex : txvm.getRoundIndex());
+             txvm.update(tangle, snapshotProvider.getInitialSnapshot(), "roundIndex");
              txvm.setConfirmations(txvm.getConfirmations() + 1);
+             txvm.update(tangle, snapshotProvider.getInitialSnapshot(), "confirmation");
          }
     }
 
@@ -317,7 +319,7 @@ public class MilestoneTrackerImpl implements MilestoneTracker {
                                 currentRoundViewModel.store(tangle);
                             }
                             addMilestoneToRoundLog(transaction.getHash(), roundIndex, currentRoundViewModel.size(), validators.size());
-                            //setRoundIndexAndConfirmations(currentRoundViewModel, transaction, roundIndex); // todo: uncomment when confirmation count resolved
+                            setRoundIndexAndConfirmations(currentRoundViewModel, transaction, roundIndex);
                         }
 
                         if (!transaction.isSolid()) {
@@ -395,6 +397,10 @@ public class MilestoneTrackerImpl implements MilestoneTracker {
             checkIfInitializationComplete();
         } catch (MilestoneException e) {
             log.error("error while analyzing the milestone candidates", e);
+        }catch (Exception e) {
+            log.error("error while running milestone tracker thread", e);
+        } catch (Throwable t) {
+            log.error("Throwable  while running milestone tracker thread", t);
         }
     }
 

--- a/src/main/java/net/helix/pendulum/service/milestone/impl/MilestoneTrackerImpl.java
+++ b/src/main/java/net/helix/pendulum/service/milestone/impl/MilestoneTrackerImpl.java
@@ -186,7 +186,7 @@ public class MilestoneTrackerImpl implements MilestoneTracker {
     public void setRoundIndexAndConfirmations(RoundViewModel currentRVM, TransactionViewModel transaction,  int roundIndex) throws Exception {
         //TODO: Fix this for confirmationStates
          // milestone referenced tip set
-         Set<Hash> referencedTipSet = currentRVM.getReferencedTransactions(tangle, RoundViewModel.getTipSet(tangle, transaction.getHash(), config.getValidatorSecurity()));
+         Set<Hash> referencedTipSet = currentRVM.getReferencedTransactions(tangle, RoundViewModel.getTipSet(tangle, transaction.getHash(), config.getValidatorSecurity()), false);
          // Milestone that first references a transaction determines the roundIndex - it should not change after that.
          // The confirmation counter should be incremented with each milestone reference
          for (Hash tx : referencedTipSet) {


### PR DESCRIPTION
There are 2 fixes in this MR:

1. candidateTracker.getValidatorsOfRound returns list of TransactionHash instead of AddressHash, because of this not all validators addresses are recognized as validator.
2. Add a seen list in RoundViewModel.getReferencedTransaction so that we don't processed twice the same transaction, in some cases it could run in a infinite loop.