### PR TITLE
1.0.3-patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,7 @@ spent-addresses-log
 *.snapshot.state
 *.snapshot.meta.bkp
 *.snapshot.state.bkp
-snapshot/*
+snapshot-*/*
 
 # modules
 XI

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,3 @@ script:
 # run jar sanity tests
 - VERSION=$(mvn help:evaluate -Dexpression=project.version | grep -E '^[0-9.]+')
 - echo $VERSION
-
-after_success:
-  - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,12 +39,4 @@ script:
 - echo $VERSION
 
 after_success:
-  - bash <(curl -s https://codecov.io/bash) -t 84b2530c-63d2-4e67-9aec-fabf6d7ccbde
-
-notifications:
-    webhooks:
-        urls:
-            - "https://scalar.vector.im/api/neb/services/hooks/dHJhdmlzLWNpLyU0MG9mbzQyJTNBbWF0cml4Lm9yZy8lMjFmeXVaWHN3RHNNTWxPbHlXbVklM0FtYXRyaXgub3Jn"
-        on_success: change  # always|never|change
-        on_failure: always
-        on_start: never
+  - bash <(curl -s https://codecov.io/bash)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 -  Integrated `getConfirmationState`: "ConfirmationState" (previously "InclusionState") is computed using `tx.confirmations` and `CONFIRMATION_THRESHOLD`. This is a preliminary modification to enable a more liveness-oriented design, in which a client does not see the states "pending" / "confirmed", but constant updates of the relative confirmations, _until_ a specifiable threshold is reached, at which we consider a transaction confirmed (finalized). Details will be available in the [specifications](https://github.com/HelixNetwork/helix-specs/tree/master/specs/1.0).
 -  Added trace logs for balance inconsistency checks (#209)
 -  Added additional logging for upcoming snapshotting changes (#210)
+-  Optimized logging levels and readability
+-  Testnet option now uses correct testnet genesis time
 
 ## 1.0.2
 -  Added roundIndex to transaction meta data

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.6</version>
+            <version>2.9.10</version>
         </dependency>
 
         <!-- undertow server -->

--- a/src/main/java/net/helix/pendulum/Main.java
+++ b/src/main/java/net/helix/pendulum/Main.java
@@ -143,11 +143,6 @@ public class Main {
                 validatorPublisher = new ValidatorPublisher(config, api);
                 validatorPublisher.startScheduledExecutorService();
             }
-            /* todo: disable spammer temporarily
-            if (config.getSpamDelay() > 0) {
-                spammer = new Spammer(config, api);
-                spammer.startScheduledExecutorService();
-            }*/
         }
 
         /**

--- a/src/main/java/net/helix/pendulum/conf/BasePendulumConfig.java
+++ b/src/main/java/net/helix/pendulum/conf/BasePendulumConfig.java
@@ -126,7 +126,6 @@ public abstract class BasePendulumConfig implements PendulumConfig {
     protected boolean validator = Defaults.VALIDATOR;
     protected Set<Hash> initialValidators = Defaults.INITIAL_VALIDATORS;
     protected long genesisTime = Defaults.GENESIS_TIME;
-    protected long genesisTimeTestnet = Defaults.GENESIS_TIME_TESTNET;
     protected int roundDuration = Defaults.ROUND_DURATION;
     protected int roundPause = Defaults.ROUND_PAUSE;
     protected String resourcePath = Defaults.RESOUCER_PATH;
@@ -849,15 +848,6 @@ public abstract class BasePendulumConfig implements PendulumConfig {
     protected void setGenesisTime(int genesisTime) { this.genesisTime = genesisTime; }
 
     @Override
-    public long getGenesisTimeTestnet() {
-        return genesisTimeTestnet;
-    }
-
-    @JsonProperty
-    @Parameter(names = {"--genesis-testnet"}, description = MilestoneConfig.Descriptions.GENESIS_TIME)
-    protected void setGenesisTimeTestnet(int genesisTimeTestnet) { this.genesisTimeTestnet = genesisTimeTestnet; }
-
-    @Override
     public int getRoundDuration() {
         return roundDuration;
     }
@@ -1037,7 +1027,6 @@ public abstract class BasePendulumConfig implements PendulumConfig {
         ));
 
         long GENESIS_TIME = 1569024001000L;
-        long GENESIS_TIME_TESTNET = 1568725976628L; //TODO: testnet flag should use this time.
         int ROUND_DURATION = 15000;
         int ROUND_PAUSE = 5000;
         String VALIDATOR_KEYFILE = "/Validator.key";
@@ -1055,7 +1044,7 @@ public abstract class BasePendulumConfig implements PendulumConfig {
         int LOCAL_SNAPSHOTS_PRUNING_DELAY = 50000;
         int LOCAL_SNAPSHOTS_INTERVAL_SYNCED = 10;
         int LOCAL_SNAPSHOTS_INTERVAL_UNSYNCED = 1000;
-        String LOCAL_SNAPSHOTS_BASE_PATH = "./snapshot";
+        String LOCAL_SNAPSHOTS_BASE_PATH = "./snapshot-mainnet";
         int LOCAL_SNAPSHOTS_DEPTH = 100;
         String SNAPSHOT_FILE = "/snapshotMainnet.txt";
         String SNAPSHOT_SIG_FILE = "/snapshotMainnet.sig";

--- a/src/main/java/net/helix/pendulum/conf/BasePendulumConfig.java
+++ b/src/main/java/net/helix/pendulum/conf/BasePendulumConfig.java
@@ -130,7 +130,7 @@ public abstract class BasePendulumConfig implements PendulumConfig {
     protected int roundDuration = Defaults.ROUND_DURATION;
     protected int roundPause = Defaults.ROUND_PAUSE;
     protected String resourcePath = Defaults.RESOUCER_PATH;
-    protected String defaultResoucePath = Defaults.DEFAULT_RESOUCE_PATH;
+    protected String defaultResourcePath = Defaults.DEFAULT_RESOUCE_PATH;
     protected int milestoneKeyDepth = Defaults.MILESTONE_KEY_DEPTH;
     protected int validatorSecurity = Defaults.VALIDATOR_SECURITY;
 
@@ -896,7 +896,7 @@ public abstract class BasePendulumConfig implements PendulumConfig {
 
     @Override
     public String getResourcePath() {
-       return Files.isDirectory(Paths.get(resourcePath)) ?  resourcePath : defaultResoucePath; }
+       return Files.isDirectory(Paths.get(resourcePath)) ?  resourcePath : defaultResourcePath; }
 
     @Override
     public int getMilestoneKeyDepth() {return milestoneKeyDepth; }

--- a/src/main/java/net/helix/pendulum/conf/MilestoneConfig.java
+++ b/src/main/java/net/helix/pendulum/conf/MilestoneConfig.java
@@ -39,10 +39,6 @@ public interface MilestoneConfig extends Config {
      */
     long getGenesisTime();
     /**
-     * @return {@value Descriptions#GENESIS_TIME}
-     */
-    long getGenesisTimeTestnet();
-    /**
      * @return {@value Descriptions#ROUND_DURATION}
      */
     int getRoundDuration();

--- a/src/main/java/net/helix/pendulum/conf/TestnetConfig.java
+++ b/src/main/java/net/helix/pendulum/conf/TestnetConfig.java
@@ -17,6 +17,7 @@ public class TestnetConfig extends BasePendulumConfig {
     protected int numberOfKeysInMilestone = Defaults.KEYS_IN_MILESTONE;
     protected int transactionPacketSize = Defaults.PACKET_SIZE;
     protected int requestHashSize = Defaults.REQUEST_HASH_SIZE;
+    protected long genesisTime= Defaults.GENESIS_TIME;
 
     public TestnetConfig() {
         super();
@@ -147,9 +148,19 @@ public class TestnetConfig extends BasePendulumConfig {
         super.setDbLogPath(dbLogPath);
     }
 
+    @Override
+    public long getGenesisTime() {
+        return genesisTime;
+    }
+
+    @JsonProperty
+    @Parameter(names = {"--genesis-testnet"}, description = MilestoneConfig.Descriptions.GENESIS_TIME)
+    protected void setGenesisTime(int genesisTime) { this.genesisTime = genesisTime; }
+
     public interface Defaults {
+        long GENESIS_TIME = 1571279107785L;
         boolean DONT_VALIDATE_MILESTONE_SIG = false;
-        String LOCAL_SNAPSHOTS_BASE_PATH = "testnet";
+        String LOCAL_SNAPSHOTS_BASE_PATH = "snapshot-testnet";
         String SNAPSHOT_FILE = "/snapshotTestnet.txt";
         int REQUEST_HASH_SIZE = 32;
         String SNAPSHOT_SIG = "/snapshotTestnet.sig";

--- a/src/main/java/net/helix/pendulum/service/API.java
+++ b/src/main/java/net/helix/pendulum/service/API.java
@@ -1554,7 +1554,7 @@ public class API {
      */
     private void storeAndBroadcast(Hash tip1, Hash tip2, int mwm, List<String> txs) throws Exception{
         List<String> powResult = attachToTangleStatement(tip1, tip2, mwm, txs);
-        log.debug("Milestone tips 1 & 2 = {} {}", tip1.toString(), tip2.toString());
+        log.trace("tips = [{}, {}]", tip1.toString(), tip2.toString());
         storeTransactionsStatement(powResult);
         broadcastTransactionsStatement(powResult);
     }
@@ -1619,7 +1619,7 @@ public class API {
     public void publishMilestone(final String address, final int minWeightMagnitude, boolean sign, int keyIndex, int maxKeyIndex) throws Exception {
 
         int currentRoundIndex = milestoneTracker.getCurrentRoundIndex();
-        log.debug("Current round index = {}", currentRoundIndex);
+        log.trace("currentRoundIndex = {}", currentRoundIndex);
         List<Hash> confirmedTips = getConfirmedTips();
         byte[] tipsBytes = Hex.decode(confirmedTips.stream().map(Hash::toString).collect(Collectors.joining()));
 

--- a/src/main/java/net/helix/pendulum/service/milestone/impl/MilestonePublisher.java
+++ b/src/main/java/net/helix/pendulum/service/milestone/impl/MilestonePublisher.java
@@ -183,11 +183,11 @@ public class MilestonePublisher {
             }
         }
         if (active) {
-            log.debug("Publishing next Milestone...");
+            log.trace("Publishing next Milestone...");
             if (currentKeyIndex < maxKeyIndex * (keyfileIndex + 1) - 1) {
                 //api.publishMilestone(address.toString(), mwm, sign, currentKeyIndex, maxKeyIndex);  <- todo remove when refactoring is done
                 //api.publish(BundleTypes.milestone, address.toString(), mwm, sign, currentKeyIndex, maxKeyIndex, false, 0);
-                log.debug("Address of milestone to publish = {}", address.toString());
+                log.trace("Address of milestone to publish = {}", address.toString());
                 api.publishMilestone(address.toString(), mwm, sign, currentKeyIndex, maxKeyIndex);
                 currentKeyIndex += 1;
             } else {

--- a/src/main/java/net/helix/pendulum/service/milestone/impl/MilestonePublisher.java
+++ b/src/main/java/net/helix/pendulum/service/milestone/impl/MilestonePublisher.java
@@ -178,7 +178,7 @@ public class MilestonePublisher {
                 log.debug("Legitimized validator {} for round #{}", address, startRound);
             }
             if (startRound == getRound(RoundIndexUtil.getCurrentTime())) {
-                log.debug("Submitting milestones in {} interval: ", (config.getRoundDuration() / 1000) + "s");
+                log.trace("Milestone rate: {}s", config.getRoundDuration() / 1000);
                 active = true;
             }
         }

--- a/src/main/java/net/helix/pendulum/service/milestone/impl/MilestoneTrackerImpl.java
+++ b/src/main/java/net/helix/pendulum/service/milestone/impl/MilestoneTrackerImpl.java
@@ -265,7 +265,7 @@ public class MilestoneTrackerImpl implements MilestoneTracker {
     @Override
     public boolean processMilestoneCandidate(TransactionViewModel transaction) throws MilestoneException {
         try {
-            log.debug("Process Milestone txhash / round " + transaction.getHash() + " " +  RoundViewModel.getRoundIndex(transaction));
+            log.debug("Process Milestone: [hash: " + transaction.getHash() +  ", round: " + RoundViewModel.getRoundIndex(transaction) + "]");
 
             int roundIndex = RoundViewModel.getRoundIndex(transaction);
             int currentRound = getCurrentRoundIndex();

--- a/src/main/java/net/helix/pendulum/service/milestone/impl/MilestoneTrackerImpl.java
+++ b/src/main/java/net/helix/pendulum/service/milestone/impl/MilestoneTrackerImpl.java
@@ -2,6 +2,7 @@ package net.helix.pendulum.service.milestone.impl;
 
 import net.helix.pendulum.conf.BasePendulumConfig;
 import net.helix.pendulum.conf.PendulumConfig;
+import net.helix.pendulum.conf.TestnetConfig;
 import net.helix.pendulum.controllers.*;
 import net.helix.pendulum.crypto.SpongeFactory;
 import net.helix.pendulum.model.Hash;
@@ -222,7 +223,7 @@ public class MilestoneTrackerImpl implements MilestoneTracker {
     @Override
     public int getRound(long time) {
         return config.isTestnet() ?
-                RoundIndexUtil.getRound(time, BasePendulumConfig.Defaults.GENESIS_TIME_TESTNET, BasePendulumConfig.Defaults.ROUND_DURATION) :
+                RoundIndexUtil.getRound(time, TestnetConfig.Defaults.GENESIS_TIME, BasePendulumConfig.Defaults.ROUND_DURATION) :
                 RoundIndexUtil.getRound(time, BasePendulumConfig.Defaults.GENESIS_TIME, BasePendulumConfig.Defaults.ROUND_DURATION);
     }
 

--- a/src/main/java/net/helix/pendulum/service/milestone/impl/MilestoneTrackerImpl.java
+++ b/src/main/java/net/helix/pendulum/service/milestone/impl/MilestoneTrackerImpl.java
@@ -367,12 +367,10 @@ public class MilestoneTrackerImpl implements MilestoneTracker {
                 TimeUnit.MILLISECONDS);
     }
 
-
     @Override
     public void shutdown() {
         executorService.shutdownNow();
     }
-
 
     /**
      * This method contains the logic for scanning for new latest milestones that gets executed in a background
@@ -390,7 +388,6 @@ public class MilestoneTrackerImpl implements MilestoneTracker {
             // additional log message on the first run to indicate how many milestone candidates we have in total
             if (firstRun) {
                 firstRun = false;
-
                 logProgress();
             }
 

--- a/src/main/java/net/helix/pendulum/service/snapshot/impl/LocalSnapshotManagerImpl.java
+++ b/src/main/java/net/helix/pendulum/service/snapshot/impl/LocalSnapshotManagerImpl.java
@@ -138,7 +138,7 @@ public class LocalSnapshotManagerImpl implements LocalSnapshotManager {
             log.trace("monitorThread.localSnapshotInterval = {}", localSnapshotInterval);
             log.trace("milestoneTracker.getCurrentRoundIndex() = {}", milestoneTracker.getCurrentRoundIndex());
             log.trace("getLatestSnapshot().getIndex() = {}", snapshotProvider.getLatestSnapshot().getIndex());
-            log.debug("Sync check = {}", milestoneTracker.getCurrentRoundIndex() -  snapshotProvider.getLatestSnapshot().getIndex());
+            log.trace("Sync check = {}", milestoneTracker.getCurrentRoundIndex() -  snapshotProvider.getLatestSnapshot().getIndex());
             int latestSnapshotIndex = snapshotProvider.getLatestSnapshot().getIndex();
             int initialSnapshotIndex = snapshotProvider.getInitialSnapshot().getIndex();
             log.trace("Taking local snapshot in ... {}",

--- a/src/main/java/net/helix/pendulum/service/snapshot/impl/LocalSnapshotManagerImpl.java
+++ b/src/main/java/net/helix/pendulum/service/snapshot/impl/LocalSnapshotManagerImpl.java
@@ -152,7 +152,6 @@ public class LocalSnapshotManagerImpl implements LocalSnapshotManager {
                     log.error("error while taking local snapshot", e);
                 }
             }
-
             ThreadUtils.sleep(LOCAL_SNAPSHOT_RESCAN_INTERVAL);
         }
     }

--- a/src/main/java/net/helix/pendulum/service/snapshot/impl/SnapshotServiceImpl.java
+++ b/src/main/java/net/helix/pendulum/service/snapshot/impl/SnapshotServiceImpl.java
@@ -240,7 +240,7 @@ public class SnapshotServiceImpl implements SnapshotService {
 
             cleanupOldData(config, transactionPruner, targetMilestone);
         }
-        log.debug("takeLocalSnapshot += 1");
+        log.trace("takeLocalSnapshot += 1");
         persistLocalSnapshot(snapshotProvider, newSnapshot, config);
     }
 

--- a/src/main/java/net/helix/pendulum/service/snapshot/impl/SnapshotServiceImpl.java
+++ b/src/main/java/net/helix/pendulum/service/snapshot/impl/SnapshotServiceImpl.java
@@ -2,6 +2,7 @@ package net.helix.pendulum.service.snapshot.impl;
 
 import net.helix.pendulum.conf.BasePendulumConfig;
 import net.helix.pendulum.conf.PendulumConfig;
+import net.helix.pendulum.conf.TestnetConfig;
 import net.helix.pendulum.controllers.ApproveeViewModel;
 import net.helix.pendulum.controllers.RoundViewModel;
 import net.helix.pendulum.controllers.StateDiffViewModel;
@@ -188,7 +189,7 @@ public class SnapshotServiceImpl implements SnapshotService {
     // todo: unfortunately we need to have getRound in milestoneTracker and here, as RoundIndexUtils is static and we need to check isTestnet.
     public int getRound(long time) {
         return config.isTestnet() ?
-                RoundIndexUtil.getRound(time, BasePendulumConfig.Defaults.GENESIS_TIME_TESTNET, BasePendulumConfig.Defaults.ROUND_DURATION) :
+                RoundIndexUtil.getRound(time, TestnetConfig.Defaults.GENESIS_TIME, BasePendulumConfig.Defaults.ROUND_DURATION) :
                 RoundIndexUtil.getRound(time, BasePendulumConfig.Defaults.GENESIS_TIME, BasePendulumConfig.Defaults.ROUND_DURATION);
     }
 

--- a/src/main/java/net/helix/pendulum/service/spentaddresses/impl/SpentAddressesServiceImpl.java
+++ b/src/main/java/net/helix/pendulum/service/spentaddresses/impl/SpentAddressesServiceImpl.java
@@ -105,7 +105,7 @@ public class SpentAddressesServiceImpl implements SpentAddressesService {
             spentAddressesProvider.saveAddressesBatch(addressesToCheck.stream()
                     .filter(ThrowingPredicate.unchecked(this::wasAddressSpentFrom))
                     .collect(Collectors.toList()));
-            log.debug("spentAddressesService.persistSpentAddresses += 1");
+            log.trace("spentAddressesService.persistSpentAddresses += 1");
         } catch (RuntimeException e) {
             if (e.getCause() instanceof SpentAddressesException) {
                 throw (SpentAddressesException) e.getCause();


### PR DESCRIPTION
-  Optimized logging levels and readability
-  Removed redundant `genesisTimeTestnet` parameter
- Set `GENESIS_TIME` in `TestnetConfig`  according to [helix-dao-data](https://github.com/HelixNetwork/helix-dao-data#genesis-time)
- Distinction between testnet and mainnet local snapshot dirs
- Minor cleanup