### PR TITLE
ZMQ topics for visualisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.4
+-  Added `vis`, `lmr` and `ctx` zmq [topics](https://github.com/HelixNetwork/pendulum#messageq) for tracking basic info for visualisation.
+
 ## 1.0.3
 -  Integrated `getConfirmationState`: "ConfirmationState" (previously "InclusionState") is computed using `tx.confirmations` and `CONFIRMATION_THRESHOLD`. This is a preliminary modification to enable a more liveness-oriented design, in which a client does not see the states "pending" / "confirmed", but constant updates of the relative confirmations, _until_ a specifiable threshold is reached, at which we consider a transaction confirmed (finalized). Details will be available in the [specifications](https://github.com/HelixNetwork/helix-specs/tree/master/specs/1.0).
 -  Added trace logs for balance inconsistency checks #209

--- a/README.md
+++ b/README.md
@@ -187,12 +187,14 @@ Currently the following topics are covered:
 | `antn`      | Added non-tethered neighbors (testnet only)                             |
 | `rntn`      | Refused non-tethered neighbors                                          |
 | `rtl`       | for transactions randomly removed from the request list                 |
-| `lmi`       | Latest solid milestone index                                            |
-| `lmhs`      | Latest solid milestone hash                                             |
+| `lmi`       | Latest milestone index and hash                                         |
 | `sn`        | Uses solid milestone's child measurement to publish newly confirmed tx. |
 | `tx`        | Newly seen transactions                                                 |
 | `ct5s2m`    | Confirmed transactions older than 5s and younger than 2m                |
 | `t5s2m`     | total transactions older than 5s and younger than 2m                    |
+| `vis`       | `tx_hash`, `branch_tx`, `trunk_tx`                                      |
+| `lmr`       | list of milestone references                                            |
+| `ctx`       | list of finalized transactions                                          |
 | `<Address>` | Watching all traffic on a specified address                             |
 
 <!-- [1]: https://javadoc-badge.appspot.com/helixnetwork/helix-1.0.svg?label=javadocs -->

--- a/src/main/java/net/helix/pendulum/network/Node.java
+++ b/src/main/java/net/helix/pendulum/network/Node.java
@@ -468,10 +468,11 @@ public class Node {
                 transactionValidator.updateStatus(receivedTransactionViewModel);
                 receivedTransactionViewModel.updateSender(neighbor.getAddress().toString());
                 receivedTransactionViewModel.update(tangle, snapshotProvider.getInitialSnapshot(), "arrivalTime|sender");
+                tangle.publish("vis %s %s %s", receivedTransactionViewModel.getHash(), receivedTransactionViewModel.getTrunkTransactionHash(), receivedTransactionViewModel.getBranchTransactionHash());
             } catch (Exception e) {
                 log.error("Error updating transactions.", e);
             }
-            log.debug("Stored_txhash = {}", receivedTransactionViewModel.getHash().toString());
+            log.trace("Stored_txhash = {}", receivedTransactionViewModel.getHash().toString());
             neighbor.incNewTransactions();
             broadcast(receivedTransactionViewModel);
 

--- a/src/main/java/net/helix/pendulum/service/API.java
+++ b/src/main/java/net/helix/pendulum/service/API.java
@@ -599,6 +599,7 @@ public class API {
                 }
                 transactionViewModel.updateSender("local");
                 transactionViewModel.update(tangle, snapshotProvider.getInitialSnapshot(), "sender");
+                tangle.publish("vis %s %s %s", transactionViewModel.getHash(), transactionViewModel.getTrunkTransactionHash(), transactionViewModel.getBranchTransactionHash());
                 log.trace("Stored_txhash = {}", transactionViewModel.getHash().toString());
             }
         }

--- a/src/main/java/net/helix/pendulum/service/API.java
+++ b/src/main/java/net/helix/pendulum/service/API.java
@@ -599,7 +599,9 @@ public class API {
                 }
                 transactionViewModel.updateSender("local");
                 transactionViewModel.update(tangle, snapshotProvider.getInitialSnapshot(), "sender");
-                tangle.publish("vis %s %s %s", transactionViewModel.getHash(), transactionViewModel.getTrunkTransactionHash(), transactionViewModel.getBranchTransactionHash());
+                if (tangle != null) {
+                    tangle.publish("vis %s %s %s", transactionViewModel.getHash(), transactionViewModel.getTrunkTransactionHash(), transactionViewModel.getBranchTransactionHash());
+                }
                 log.trace("Stored_txhash = {}", transactionViewModel.getHash().toString());
             }
         }

--- a/src/main/java/net/helix/pendulum/service/milestone/impl/LatestSolidMilestoneTrackerImpl.java
+++ b/src/main/java/net/helix/pendulum/service/milestone/impl/LatestSolidMilestoneTrackerImpl.java
@@ -1,5 +1,6 @@
 package net.helix.pendulum.service.milestone.impl;
 
+import net.helix.pendulum.conf.BasePendulumConfig;
 import net.helix.pendulum.controllers.RoundViewModel;
 import net.helix.pendulum.controllers.TransactionViewModel;
 import net.helix.pendulum.model.Hash;
@@ -159,12 +160,10 @@ public class LatestSolidMilestoneTrackerImpl implements LatestSolidMilestoneTrac
                     }
                 }
                 if (isRoundSolid(nextRound)) {
-                    // TODO: Ask Oliver about these classes?
-                    //syncValidatorTracker();
-                    //syncLatestMilestoneTracker(nextRound.index());
                     applyRoundToLedger(nextRound);
                     logChange(currentSolidRoundIndex);
                     currentSolidRoundIndex = snapshotProvider.getLatestSnapshot().getIndex();
+                    tangle.publish("ctx %s %d", nextRound.getReferencedTransactions(tangle, nextRound.getConfirmedTips(tangle, BasePendulumConfig.Defaults.VALIDATOR_SECURITY)), nextRound.index());
                 }
             }
         } catch (Exception e) {

--- a/src/main/java/net/helix/pendulum/service/milestone/impl/MilestoneTrackerImpl.java
+++ b/src/main/java/net/helix/pendulum/service/milestone/impl/MilestoneTrackerImpl.java
@@ -6,7 +6,6 @@ import net.helix.pendulum.conf.TestnetConfig;
 import net.helix.pendulum.controllers.*;
 import net.helix.pendulum.crypto.SpongeFactory;
 import net.helix.pendulum.model.Hash;
-import net.helix.pendulum.model.persistables.Transaction;
 import net.helix.pendulum.service.milestone.MilestoneException;
 import net.helix.pendulum.service.milestone.MilestoneService;
 import net.helix.pendulum.service.milestone.MilestoneSolidifier;
@@ -164,7 +163,7 @@ public class MilestoneTrackerImpl implements MilestoneTracker {
         return this;
     }
 
-    private void publishMilestoneRefs(TransactionViewModel transaction, int roundIndex) throws Exception {
+    private void publishMilestoneRefs(TransactionViewModel transaction) throws Exception {
         BundleViewModel bundle = BundleViewModel.load(tangle, transaction.getBundleHash());
         for (Hash tx: bundle.getHashes()) {
             tangle.publish("lmr %s %s %s", tx, "Branch " + RoundViewModel.getMilestoneBranch(tangle, TransactionViewModel.fromHash(tangle, tx), transaction, config.getValidatorSecurity()), "Trunk " + RoundViewModel.getMilestoneTrunk(tangle, TransactionViewModel.fromHash(tangle, tx), transaction));
@@ -329,7 +328,7 @@ public class MilestoneTrackerImpl implements MilestoneTracker {
                             }
                             addMilestoneToRoundLog(transaction.getHash(), roundIndex, currentRoundViewModel.size(), validators.size());
                             setRoundIndexAndConfirmations(currentRoundViewModel, transaction, roundIndex);
-                            publishMilestoneRefs(transaction, roundIndex);
+                            publishMilestoneRefs(transaction);
                         }
 
                         if (!transaction.isSolid()) {


### PR DESCRIPTION
Added `vis`, `lmr` and `ctx` zmq [topics](https://github.com/HelixNetwork/pendulum#messageq) to track basic info for visualisation.