### PR TITLE
Fixes & Cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 1.0.5
--  Fixed `getBalance`: RoundViewModel returns null on index=0, thus NPE was thrown when `references` were not passed and the first round hadn't been completed. In our implementation the snapshot is already constructed based on relative confirmations, thus it suffices for `getBalances` to respond with balance according to `latestSnapshot`.
+-  Fixed `getBalance`: `RoundViewModel.get()` returns null on `index`=0, thus NPE was thrown when `references` were not passed and the first round hadn't been completed. In our implementation the snapshot is already constructed based on relative confirmations, thus it suffices for `getBalances` to respond with balance according to `latestSnapshot`.
 
 ## 1.0.4
 -  Fixed several zmq publish statements in which an incorrect format was specified.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.5
+-  Fixed `getBalance`: RoundViewModel returns null on index=0, thus NPE was thrown when `references` were not passed and the first round hadn't been completed. In our implementation the snapshot is already constructed based on relative confirmations, thus it suffices for `getBalances` to respond with balance according to `latestSnapshot`.
+
 ## 1.0.4
 -  Fixed several zmq publish statements in which an incorrect format was specified.
 -  Added `vis`, `lmr` and `ctx` zmq [topics](https://github.com/HelixNetwork/pendulum#messageq) to track basic info for visualisation.

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>pendulum</artifactId>
 
 
-    <version>1.0.4</version>
+    <version>1.0.5</version>
 
 
     <name>Pendulum</name>

--- a/src/main/java/net/helix/pendulum/Main.java
+++ b/src/main/java/net/helix/pendulum/Main.java
@@ -46,7 +46,7 @@ public class Main {
     public static final String MAINNET_NAME = "Pendulum";
     public static final String TESTNET_NAME = "Pendulum Testnet";
 
-    public static final String VERSION = "1.0.4";
+    public static final String VERSION = "1.0.5";
 
 
     /**

--- a/src/main/java/net/helix/pendulum/service/API.java
+++ b/src/main/java/net/helix/pendulum/service/API.java
@@ -1103,46 +1103,30 @@ public class API {
 
     /**
      * <p>
-     *     Calculates the confirmed balance, as viewed by the specified <tt>tips</tt>.
-     *     If you do not specify the referencing <tt>tips</tt>,
-     *     the returned balance is based on the latest confirmed milestone.
-     *     In addition to the balances, it also returns the referencing <tt>tips</tt> (or milestone),
-     *     as well as the index with which the confirmed balance was determined.
+     *     Calculates the confirmed balance based on the latest confirmed milestone.
      *     The balances are returned as a list in the same order as the addresses were provided as input.
      * </p>
      * Returns an {@link ErrorResponse} if tips are not found, inconsistent or the threshold is invalid.
      *
      * @param addresses The addresses where we will find the balance for.
-     * @param tips The optional tips to find the balance through.
      * @param threshold The confirmation threshold between 0 and 100(inclusive).
      *                  Should be set to 100 for getting balance by counting only confirmed transactions.
      * @return {@link net.helix.pendulum.service.dto.GetBalancesResponse}
      * @throws Exception When the database has encountered an error
      **/
-    private AbstractResponse getBalancesStatement(List<String> addresses,
-                                                  List<String> tips,
-                                                  int threshold) throws Exception {
+    private AbstractResponse getBalancesStatement(List<String> addresses, int threshold) throws Exception {
 
         if (threshold <= 0 || threshold > 100) {
             return ErrorResponse.create("Illegal 'threshold'");
         }
 
         final List<Hash> addressList = addresses.stream()
-                .map(address -> (HashFactory.ADDRESS.create(address)))
+                .map(HashFactory.ADDRESS::create)
                 .collect(Collectors.toCollection(LinkedList::new));
 
-        final List<Hash> hashes;
         final Map<Hash, Long> balances = new HashMap<>();
         snapshotProvider.getLatestSnapshot().lockRead();
         final int index = snapshotProvider.getLatestSnapshot().getIndex();
-
-        if (tips == null || tips.size() == 0) {
-            hashes = new LinkedList<>(RoundViewModel.get(tangle, index).getHashes());
-        } else {
-            hashes = tips.stream()
-                    .map(tip -> (HashFactory.TRANSACTION.create(tip)))
-                    .collect(Collectors.toCollection(LinkedList::new));
-        }
 
         try {
             // Get the balance for each address at the last snapshot
@@ -1153,23 +1137,6 @@ public class API {
                 }
                 balances.put(address, value);
             }
-
-            final Set<Hash> visitedHashes = new HashSet<>();
-            final Map<Hash, Long> diff = new HashMap<>();
-
-            // Calculate the difference created by the non-verified transactions which tips approve.
-            // This difference is put in a map with address -> value changed
-            for (Hash tip : hashes) {
-                if (!TransactionViewModel.exists(tangle, tip)) {
-                    return ErrorResponse.create("Tip not found: " + Hex.toHexString(tip.bytes()));
-                }
-                if (!ledgerService.isBalanceDiffConsistent(visitedHashes, diff, tip)) {
-                    return ErrorResponse.create("Tips are not consistent");
-                }
-            }
-
-            // Update the found balance according to 'diffs' balance changes
-            diff.forEach((key, value) -> balances.computeIfPresent(key, (hash, aLong) -> value + aLong));
         } finally {
             snapshotProvider.getLatestSnapshot().unlockRead();
         }
@@ -1178,9 +1145,7 @@ public class API {
                 .map(address -> balances.get(address).toString())
                 .collect(Collectors.toCollection(LinkedList::new));
 
-        return GetBalancesResponse.create(elements, hashes.stream()
-                .map(h -> Hex.toHexString(h.bytes()))
-                .collect(Collectors.toList()), index);
+        return GetBalancesResponse.create(elements, index);
     }
 
     /**
@@ -1764,13 +1729,10 @@ public class API {
     private Function<Map<String, Object>, AbstractResponse> getBalances() {
         return request -> {
             final List<String> addresses = getParameterAsList(request,"addresses", HASH_SIZE);
-            final List<String> tips = request.containsKey("tips") ?
-                    getParameterAsList(request,"tips", HASH_SIZE):
-                    null;
             final int threshold = getParameterAsInt(request, "threshold");
 
             try {
-                return getBalancesStatement(addresses, tips, threshold);
+                return getBalancesStatement(addresses, threshold);
             } catch (Exception e) {
                 throw new IllegalStateException(e);
             }

--- a/src/main/java/net/helix/pendulum/service/API.java
+++ b/src/main/java/net/helix/pendulum/service/API.java
@@ -407,7 +407,7 @@ public class API {
     }
     /**
      * Returns the set of neighbors you are connected with, as well as their activity statistics (or counters).
-     * The activity counters are reset after restarting IRI.
+     * The activity counters are reset after restarting the node.
      *
      * @return {@link net.helix.pendulum.service.dto.GetNeighborsResponse}
      **/

--- a/src/main/java/net/helix/pendulum/service/API.java
+++ b/src/main/java/net/helix/pendulum/service/API.java
@@ -1623,7 +1623,7 @@ public class API {
 
         int currentRoundIndex = milestoneTracker.getCurrentRoundIndex();
         log.trace("currentRoundIndex = {}", currentRoundIndex);
-        List<Hash> confirmedTips = getConfirmedTips();
+        List<Hash> confirmedTips = getConsistentTips();
         byte[] tipsBytes = Hex.decode(confirmedTips.stream().map(Hash::toString).collect(Collectors.joining()));
 
         List<Hash> txToApprove = addMilestoneReferences(confirmedTips, currentRoundIndex);
@@ -1664,8 +1664,13 @@ public class API {
     // Publish Helpers
     //
 
-    private List<Hash> getConfirmedTips() throws Exception {
-        // get confirming tips (this must be the first step to make sure no other milestone references the tips before this node catches them)
+    /**
+     * get consistent tips
+     * All validators should first get consistent tips before broadcasting their milestones.
+     * @return consistent tips
+     * @throws Exception Exception
+     */
+    private List<Hash> getConsistentTips() throws Exception {
         List<Hash> confirmedTips = new LinkedList<>();
 
         snapshotProvider.getLatestSnapshot().lockRead();

--- a/src/main/java/net/helix/pendulum/service/dto/GetBalancesResponse.java
+++ b/src/main/java/net/helix/pendulum/service/dto/GetBalancesResponse.java
@@ -18,11 +18,6 @@ public class GetBalancesResponse extends AbstractResponse {
 	private List<String> balances;
 
 	/**
-	 * The tips used to view the balances. If none were supplied this will be the latest confirmed milestone.
-	 */
-	private List<String> references;
-
-	/**
 	 * The milestone index with which the confirmed balance was determined
 	 */
 	private int milestoneIndex;
@@ -31,24 +26,14 @@ public class GetBalancesResponse extends AbstractResponse {
 	 * Creates a new {@link GetBalancesResponse}
 	 *
 	 * @param elements {@link #balances}
-	 * @param references {@link #references}
 	 * @param milestoneIndex {@link #milestoneIndex}
 	 * @return an {@link GetBalancesResponse} filled with the balances, references used and index used
 	 */
-	public static AbstractResponse create(List<String> elements, List<String> references, int milestoneIndex) {
+	public static AbstractResponse create(List<String> elements,  int milestoneIndex) {
 		GetBalancesResponse res = new GetBalancesResponse();
 		res.balances = elements;
-		res.references = references;
 		res.milestoneIndex = milestoneIndex;
 		return res;
-	}
-
-	/**
-	 *
-	 * @return {@link #references}
-	 */
-	public List<String> getReferences() {
-		return references;
 	}
 
 	/**

--- a/src/main/java/net/helix/pendulum/service/ledger/LedgerService.java
+++ b/src/main/java/net/helix/pendulum/service/ledger/LedgerService.java
@@ -90,6 +90,4 @@ public interface LedgerService {
      */
     Map<Hash, Long> generateBalanceDiff(Set<Hash> visitedTransactions, Set<Hash> startTransactions, int milestoneIndex)
             throws LedgerException;
-
-    boolean updateDiff(Set<Hash> approvedHashes, final Map<Hash, Long> diff, Hash tip); // temporary
 }

--- a/src/main/java/net/helix/pendulum/service/ledger/impl/LedgerServiceImpl.java
+++ b/src/main/java/net/helix/pendulum/service/ledger/impl/LedgerServiceImpl.java
@@ -80,12 +80,6 @@ public class LedgerServiceImpl implements LedgerService {
         return this;
     }
 
-
-    @Override
-    public boolean updateDiff(Set<Hash> approvedHashes, final Map<Hash, Long> diff, Hash tip) {
-        return true;
-    }
-
     @Override
     public void restoreLedgerState() throws LedgerException {
         try {
@@ -129,7 +123,6 @@ public class LedgerServiceImpl implements LedgerService {
 
         return true;
     }
-    // TODO: remove debug verbosity
     @Override
     public boolean isBalanceDiffConsistent(Set<Hash> approvedHashes, Map<Hash, Long> diff, Hash tip) throws
             LedgerException {
@@ -158,8 +151,7 @@ public class LedgerServiceImpl implements LedgerService {
                 currentState.putIfAbsent(key, value);
             }
         });
-        boolean isConsistent = snapshotProvider.getLatestSnapshot().patchedState(new SnapshotStateDiffImpl(
-                currentState)).isConsistent();
+        boolean isConsistent = snapshotProvider.getLatestSnapshot().patchedState(new SnapshotStateDiffImpl(currentState)).isConsistent();
         if (isConsistent) {
             diff.putAll(currentState);
             approvedHashes.addAll(visitedHashes);

--- a/src/main/java/net/helix/pendulum/service/milestone/MilestoneService.java
+++ b/src/main/java/net/helix/pendulum/service/milestone/MilestoneService.java
@@ -16,13 +16,13 @@ import java.util.Set;
  */
 public interface MilestoneService {
     /**
-     * Finds the latest solid milestone that was previously processed by IRI (before a restart) by performing a search
+     * Finds the latest solid milestone that was previously processed by the node (before a restart) by performing a search
      * in the database.<br />
      * <br />
      * It determines if the milestones were processed by checking the {@code snapshotIndex} value of their corresponding
      * transactions.<br />
      *
-     * @return the latest solid milestone that was previously processed by IRI or an empty value if no previously
+     * @return the latest solid milestone that was previously processed by the node or an empty value if no previously
      *         processed solid milestone can be found
      * @throws MilestoneException if anything unexpected happend while performing the search
      */
@@ -74,7 +74,7 @@ public interface MilestoneService {
      * <br />
      * This allows us to reprocess the milestone in case of errors where the given milestone could not be applied to the
      * ledger state. It is for example used by the automatic repair routine of the {@link LatestSolidMilestoneTracker}
-     * (to recover from inconsistencies due to crashes of IRI).<br />
+     * (to recover from inconsistencies due to crashes of the node).<br />
      * <br />
      * It recursively resets additional milestones if inconsistencies are found within the resetted milestone (wrong
      * {@code milestoneIndex}es).<br />

--- a/src/main/java/net/helix/pendulum/service/milestone/impl/MilestoneServiceImpl.java
+++ b/src/main/java/net/helix/pendulum/service/milestone/impl/MilestoneServiceImpl.java
@@ -256,7 +256,7 @@ public class MilestoneServiceImpl implements MilestoneService {
 
     /**
      * Performs a binary search for the latest solid milestone which was already processed by the node and applied to
-     * the ledger state at some point in the past (i.e. before IRI got restarted).<br />
+     * the ledger state at some point in the past (i.e. before the node got restarted).<br />
      * <br />
      * It searches from present to past using a binary search algorithm which quickly narrows down the amount of
      * candidates even for big databases.<br />
@@ -325,14 +325,14 @@ public class MilestoneServiceImpl implements MilestoneService {
     }
 
     /**
-     * Checks if the milestone was applied to the ledger at some point in the past (before a restart of IRI).<br />
+     * Checks if the milestone was applied to the ledger at some point in the past (before a restart of the node).<br />
      * <br />
      * Since the {@code snapshotIndex} value is used as a flag to determine if the milestone was already applied to the
-     * ledger, we can use it to determine if it was processed by IRI in the past. If this value is set we should also
+     * ledger, we can use it to determine if it was processed by the node in the past. If this value is set we should also
      * have a corresponding {@link StateDiff} entry in the database.<br />
      *
      * @param round the milestone that shall be checked
-     * @return {@code true} if the milestone has been processed by IRI before and {@code false} otherwise
+     * @return {@code true} if the milestone has been processed by the node before and {@code false} otherwise
      * @throws Exception if anything unexpected happens while checking the milestone
      */
     private boolean wasRoundAppliedToLedger(RoundViewModel round) throws Exception {

--- a/src/main/java/net/helix/pendulum/service/milestone/impl/MilestoneTrackerImpl.java
+++ b/src/main/java/net/helix/pendulum/service/milestone/impl/MilestoneTrackerImpl.java
@@ -365,7 +365,7 @@ public class MilestoneTrackerImpl implements MilestoneTracker {
      * <br />
      * We repeatedly call {@link #latestMilestoneTrackerThread()} to actively look for new milestones in our database.
      * This is a bit inefficient and should at some point maybe be replaced with a check on transaction arrival, but
-     * this would required adjustments in the whole way IRI handles transactions and is therefore postponed for
+     * this would required adjustments in the whole way the node handles transactions and is therefore postponed for
      * now.<br />
      */
     @Override

--- a/src/main/java/net/helix/pendulum/service/snapshot/SnapshotProvider.java
+++ b/src/main/java/net/helix/pendulum/service/snapshot/SnapshotProvider.java
@@ -25,7 +25,7 @@ public interface SnapshotProvider {
     /**
      * This method dumps the whole snapshot to the hard disk.
      *
-     * It is used to persist the in memory state of the snapshot and allow IRI to resume from the local snapshot after
+     * It is used to persist the in memory state of the snapshot and allow the node to resume from the local snapshot after
      * restarts.
      *
      * Note: This method writes two files - the meta data file and the state file. The path of the corresponding file is

--- a/src/main/java/net/helix/pendulum/service/snapshot/impl/SnapshotProviderImpl.java
+++ b/src/main/java/net/helix/pendulum/service/snapshot/impl/SnapshotProviderImpl.java
@@ -132,7 +132,7 @@ public class SnapshotProviderImpl implements SnapshotProvider {
      * {@inheritDoc}<br />
      * <br />
      * It first writes two temporary files, then renames the current files by appending them with a ".bkp" extension and
-     * finally renames the temporary files. This mechanism reduces the chances of the files getting corrupted if IRI
+     * finally renames the temporary files. This mechanism reduces the chances of the files getting corrupted if the node
      * crashes during the snapshot creation and always leaves the node operator with a set of backup files that can be
      * renamed to resume node operation prior to the failed snapshot.<br />
      * <br />
@@ -394,7 +394,7 @@ public class SnapshotProviderImpl implements SnapshotProvider {
     /**
      * This method dumps the current state to a file.
      *
-     * It is used by local snapshots to persist the in memory states and allow IRI to resume from the local snapshot.
+     * It is used by local snapshots to persist the in memory states and allow the node to resume from the local snapshot.
      *
      * @param snapshotState state object that shall be written
      * @param snapshotPath location of the file that shall be written

--- a/src/main/java/net/helix/pendulum/service/tipselection/impl/WalkValidatorImpl.java
+++ b/src/main/java/net/helix/pendulum/service/tipselection/impl/WalkValidatorImpl.java
@@ -60,8 +60,8 @@ public class WalkValidatorImpl implements WalkValidator {
 
         TransactionViewModel transactionViewModel = TransactionViewModel.fromHash(tangle, transactionHash);
         if (transactionViewModel.getType() == TransactionViewModel.PREFILLED_SLOT) {
-            log.debug("transactionViewModel: {} ", transactionViewModel.getBytes());
-            log.debug("transactionViewModel.Type: {} ", transactionViewModel.getType());
+            log.trace("tx_hash: {} ", transactionViewModel.getHash());
+            log.trace("type: {} ", transactionViewModel.getType());
             log.debug("Validation failed: {} is missing in db", transactionHash.toString());
             return false;
         } else if (transactionViewModel.getCurrentIndex() != 0) {
@@ -71,16 +71,11 @@ public class WalkValidatorImpl implements WalkValidator {
             log.debug("Validation failed: {} is not solid", transactionHash.toString());
             return false;
         }
-        // todo do we need this?
         /*else if (belowMaxDepth(transactionViewModel.getHash(),
                 snapshotProvider.getLatestSnapshot().getIndex() - config.getMaxDepth())) {
             log.debug("Validation failed: {} is below max depth", transactionHash.toString());
             return false;
         }*/
-            else if (!ledgerService.updateDiff(myApprovedHashes, myDiff, transactionViewModel.getHash())) {
-            log.debug("Validation failed: {} is not consistent", transactionHash.toString());
-            return false;
-        }
         else if (!ledgerService.isBalanceDiffConsistent(myApprovedHashes, myDiff, transactionViewModel.getHash())) {
             log.debug("Validation failed: {} balance is not consistent", transactionHash.toString());
             return false;

--- a/src/main/java/net/helix/pendulum/service/transactionpruning/TransactionPruner.java
+++ b/src/main/java/net/helix/pendulum/service/transactionpruning/TransactionPruner.java
@@ -34,7 +34,7 @@ public interface TransactionPruner {
      * This method saves the current state of the {@link TransactionPruner}, so it can later be restored by
      * {@link #restoreState()}.
      *
-     * It is used to maintain the state between IRI restarts and pick up pruning where it stopped when IRI shut down.
+     * It is used to maintain the state between the node restarts and pick up pruning where it stopped when the node shut down.
      *
      * @throws TransactionPruningException if anything goes wrong while saving the current state
      */
@@ -43,7 +43,7 @@ public interface TransactionPruner {
     /**
      * Restores the state of the {@link TransactionPruner} after being saved before by {@link #saveState()}.
      *
-     * It is used to keep the state between IRI restarts and pick up pruning where it stopped when IRI shut down.
+     * It is used to keep the state between the node restarts and pick up pruning where it stopped when the node shut down.
      *
      * @throws TransactionPruningException if anything goes wrong while restoring the state
      */

--- a/src/main/java/net/helix/pendulum/service/transactionpruning/async/AsyncTransactionPruner.java
+++ b/src/main/java/net/helix/pendulum/service/transactionpruning/async/AsyncTransactionPruner.java
@@ -189,7 +189,7 @@ public class AsyncTransactionPruner implements TransactionPruner {
      *
      * We incorporate a background job that periodically saves the state rather than doing it "live", to reduce the cost
      * of this operation. While this can theoretically lead to a situation where the saved state is not 100% correct and
-     * the latest changes get lost (if IRI crashes or gets restarted before the new changes could be persisted), the
+     * the latest changes get lost (if the node crashes or gets restarted before the new changes could be persisted), the
      * impact is marginal because it only leads to some floating "zombie" transactions that will stay in the database.
      * This will be "solved" once we persist the changes in the database instead of a file on the hard disk. For now the
      * trade off between faster processing times and leaving some garbage is reasonable.

--- a/src/main/java/net/helix/pendulum/service/transactionpruning/async/MilestonePrunerJobQueue.java
+++ b/src/main/java/net/helix/pendulum/service/transactionpruning/async/MilestonePrunerJobQueue.java
@@ -117,7 +117,7 @@ public class MilestonePrunerJobQueue implements JobQueue<MilestonePrunerJob> {
                 youngestFullyCleanedMilestoneIndex = currentJob.getTargetIndex();
 
                 // we always leave the last job in the queue to be able to "serialize" the queue status and allow
-                // to skip already processed milestones even when IRI restarts
+                // to skip already processed milestones even when the node restarts
                 if (jobs.size() == 1) {
                     break;
                 }

--- a/src/main/java/net/helix/pendulum/service/transactionpruning/jobs/MilestonePrunerJob.java
+++ b/src/main/java/net/helix/pendulum/service/transactionpruning/jobs/MilestonePrunerJob.java
@@ -80,7 +80,7 @@ public class MilestonePrunerJob extends AbstractTransactionPrunerJob {
      * progressed already to the given {@code currentIndex}.
      *
      * Since cleanup jobs can be consolidated (to reduce the size of the
-     * {@link net.helix.pendulum.service.transactionpruning.TransactionPruner} state file) and restored (after IRI restarts),
+     * {@link net.helix.pendulum.service.transactionpruning.TransactionPruner} state file) and restored (after the node restarts),
      * we need to be able provide both parameters even tho the job usually always "starts" with its {@code currentIndex}
      * being equal to the {@code startingIndex}.
      *
@@ -106,7 +106,7 @@ public class MilestonePrunerJob extends AbstractTransactionPrunerJob {
      *
      * It iterates from the {@link #currentIndex} to the provided {@link #targetIndex} and processes every milestone
      * one by one. After each step is finished we persist the progress to be able to continue with the current progress
-     * upon IRI restarts.
+     * upon the node restarts.
      */
     @Override
     public void process() throws TransactionPruningException {

--- a/src/main/java/net/helix/pendulum/service/validatormanager/impl/CandidateTrackerImpl.java
+++ b/src/main/java/net/helix/pendulum/service/validatormanager/impl/CandidateTrackerImpl.java
@@ -384,7 +384,7 @@ public class CandidateTrackerImpl implements CandidateTracker {
      * <br />
      * We repeatedly call {@link #candidateTrackerThread()} to search for new application bundles in the database.
      * This is a bit inefficient and should at some point maybe be replaced with a check on transaction arrival, but
-     * this would required adjustments in the whole way IRI (and Pendulum) handles transactions and is therefore postponed for
+     * this would required adjustments in the whole way the node (and Pendulum) handles transactions and is therefore postponed for
      * now.<br />
      */
     @Override

--- a/src/main/java/net/helix/pendulum/utils/log/ProgressLogger.java
+++ b/src/main/java/net/helix/pendulum/utils/log/ProgressLogger.java
@@ -3,7 +3,7 @@ package net.helix.pendulum.utils.log;
 import org.slf4j.Logger;
 
 /**
- * Represents a wrapper for the {@link Logger} used by IRI that implements a logic to report the progress of a single
+ * Represents a wrapper for the {@link Logger} used by the node that implements a logic to report the progress of a single
  * task.
  *
  * The progress is calculated by comparing the current step to the expected step count and shown as a percentage value.

--- a/src/main/java/net/helix/pendulum/utils/log/interval/IntervalLogger.java
+++ b/src/main/java/net/helix/pendulum/utils/log/interval/IntervalLogger.java
@@ -11,7 +11,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
- * This class represents a wrapper for the {@link org.slf4j.Logger} used by IRI that implements a logic to rate limits
+ * This class represents a wrapper for the {@link org.slf4j.Logger} used by the node that implements a logic to rate limits
  * the output on the console.
  *
  * Instead of printing all messages immediately and unnecessarily spamming the console, it only prints messages every


### PR DESCRIPTION
-  Fixed `getBalance`: `RoundViewModel.get() ` returns `null` on `index`=0, thus NPE was thrown when `references` were not passed and the first round hadn't been completed. In our implementation the snapshot is already constructed based on relative confirmations, thus it suffices for `getBalances` to respond with balance according to `latestSnapshot`. 
- Code cleanup: removed obsolete `updateDiff()`, updated todos, comments, fixed logs, renaming.
