### PR TITLE
API select random tips and do not walk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.0.5
 -  Fixed `getBalance`: `RoundViewModel.get()` returns null on `index`=0, thus NPE was thrown when `references` were not passed and the first round hadn't been completed. In our implementation the snapshot is already constructed based on relative confirmations, thus it suffices for `getBalances` to respond with balance according to `latestSnapshot`.
--  Updated `previousEpochsSpentAddresses` resource files 
+-  Updated `previousEpochsSpentAddresses` resource files
+- Added method in the tip selector to get two random tips, and thus conform to the paper of Popov.
 
 ## 1.0.4
 -  Fixed several zmq publish statements in which an incorrect format was specified.

--- a/src/main/java/net/helix/pendulum/Pendulum.java
+++ b/src/main/java/net/helix/pendulum/Pendulum.java
@@ -323,6 +323,6 @@ public class Pendulum {
         TailFinder tailFinder = new TailFinderImpl(tangle);
         Walker walker = new WalkerAlpha(tailFinder, tangle, new SecureRandom(), config);
         return new TipSelectorImpl(tangle, snapshotProvider, ledgerService, entryPointSelector, ratingCalculator,
-                walker, config);
+                walker, tipsViewModel, config);
     }
 }

--- a/src/main/java/net/helix/pendulum/controllers/TipsViewModel.java
+++ b/src/main/java/net/helix/pendulum/controllers/TipsViewModel.java
@@ -100,7 +100,8 @@ public class TipsViewModel {
         synchronized (sync) {
             int size = solidTips.size();
             if (size == 0) {
-                return getRandomNonSolidTipHash();
+                return Hash.NULL_HASH;
+                //return getRandomNonSolidTipHash(); <-- dnck remove
             }
             return getRandomTipHash(size);
             //return solidTips.size() != 0 ? solidTips.get(seed.nextInt(solidTips.size())) : getRandomNonSolidTipHash();     <- For later stage
@@ -132,7 +133,8 @@ public class TipsViewModel {
         int index = seed.nextInt(size);
         Iterator<Hash> hashIterator;
         hashIterator = tips.iterator();
-        Hash hash = null;
+        Hash hash = Hash.NULL_HASH;
+        //Hash hash = null; <-- dnck removed replaced with Null hash
         while (index-- >= 0 && hashIterator.hasNext()) {
             hash = hashIterator.next();
         }

--- a/src/main/java/net/helix/pendulum/service/API.java
+++ b/src/main/java/net/helix/pendulum/service/API.java
@@ -537,7 +537,8 @@ public class API {
             throw new IllegalStateException(INVALID_SUBTANGLE);
         }
 
-        List<Hash> tips = tipsSelector.getTransactionsToApprove(depth, reference);
+        //List<Hash> tips = tipsSelector.getTransactionsToApprove(depth, reference);
+        List<Hash> tips = tipsSelector.getTwoRandomTips();
 
         if (log.isDebugEnabled()) {
             gatherStatisticsOnTipSelection();

--- a/src/main/java/net/helix/pendulum/service/tipselection/TipSelector.java
+++ b/src/main/java/net/helix/pendulum/service/tipselection/TipSelector.java
@@ -26,4 +26,6 @@ public interface TipSelector {
      * @throws Exception If DB fails to retrieve transactions
      */
     List<Hash> getTransactionsToApprove(int depth, Optional<Hash> reference) throws Exception;
+
+    List<Hash> getTwoRandomTips() throws Exception;
 }

--- a/src/main/java/net/helix/pendulum/service/tipselection/impl/TipSelectorImpl.java
+++ b/src/main/java/net/helix/pendulum/service/tipselection/impl/TipSelectorImpl.java
@@ -1,6 +1,7 @@
 package net.helix.pendulum.service.tipselection.impl;
 
 import net.helix.pendulum.conf.TipSelConfig;
+import net.helix.pendulum.controllers.TipsViewModel;
 import net.helix.pendulum.controllers.RoundViewModel;
 import net.helix.pendulum.model.Hash;
 
@@ -17,6 +18,7 @@ import java.util.Map;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Implementation of <tt>TipSelector</tt> that selects 2 tips,
@@ -27,6 +29,8 @@ public class TipSelectorImpl implements TipSelector {
 
     private static final String REFERENCE_TRANSACTION_TOO_OLD = "reference transaction is too old";
     private static final String TIPS_NOT_CONSISTENT = "inconsistent tips pair selected";
+
+    private final TipsViewModel tipsViewModel;
 
     private final Logger log = LoggerFactory.getLogger(TipSelectorImpl.class);
     private final EntryPointSelector entryPointSelector;
@@ -55,6 +59,7 @@ public class TipSelectorImpl implements TipSelector {
                            EntryPointSelector entryPointSelector,
                            RatingCalculator ratingCalculator,
                            Walker walkerAlpha,
+                           TipsViewModel tipsViewModel,
                            TipSelConfig config) {
 
         this.entryPointSelector = entryPointSelector;
@@ -67,6 +72,7 @@ public class TipSelectorImpl implements TipSelector {
         this.tangle = tangle;
         this.snapshotProvider = snapshotProvider;
         this.config = config;
+        this.tipsViewModel = tipsViewModel;
     }
 
     /**
@@ -137,6 +143,22 @@ public class TipSelectorImpl implements TipSelector {
 
     private boolean isTangleReadyForRandomWalk() throws Exception {
         return RoundViewModel.latest(tangle) != null;
+    }
+
+    @Override
+    public List<Hash> getTwoRandomTips() throws Exception {
+        List<Hash> tips = new LinkedList<>();
+        Set<Hash> tipHashes = tipsViewModel.getTips();
+        if (tipHashes.size() < 2){
+            Hash tip0 = tipsViewModel.getRandomSolidTipHash();
+            Hash tip1 = tipsViewModel.getRandomSolidTipHash();
+            tips.add(tip0);
+            tips.add(tip1);
+            return tips;
+        }
+        tips.add(tipHashes.iterator().next());
+        tips.add(tipHashes.iterator().next());
+        return tips;
     }
 
     private void checkReference(Hash reference, Map<Hash, Integer> rating)


### PR DESCRIPTION
This is a port from the older helix-1.0 package into pendulum to stop the random walking. Tips are selected with the new tipselector.getTwoRandomTips() method.